### PR TITLE
perf: partial buffer and highlight update

### DIFF
--- a/doc/ascii-ui.txt
+++ b/doc/ascii-ui.txt
@@ -53,6 +53,16 @@ Return ~
 `(fun(): { segment: ascii-ui.Segment, position: { line: integer, col: integer } } | nil)`
 
 ------------------------------------------------------------------------------
+                                       *Buffer:iter_colored_segments_on_lines()*
+             `Buffer:iter_colored_segments_on_lines`({dirty_rows})
+Like `iter_colored_segments` but only yields segments whose 0-indexed row
+is present in `dirty_rows`.  Avoids iterating unchanged lines entirely.
+Parameters ~
+{dirty_rows} `(table<integer, boolean>)`  set of 0-indexed row numbers
+Return ~
+`(fun(): { segment: ascii-ui.Segment, position: { line: integer, col: integer } } | nil)`
+
+------------------------------------------------------------------------------
                                                            *Buffer.from_lines()*
                           `Buffer.from_lines`({lines})
 Parameters ~
@@ -1418,12 +1428,24 @@ Closes the floating window and releases the buffer handle.
 After this call `winid` and `bufnr` are `nil`.
 
 ------------------------------------------------------------------------------
+                                           *Window:_apply_highlights_for_rows()*
+          `Window:_apply_highlights_for_rows`({buffer}, {dirty_rows})
+Applies highlight extmarks for all colored segments on a specific set of
+0-indexed row numbers. Clears the namespace on those rows first so stale
+marks from a previous render are removed without touching unchanged rows.
+Anonymous color highlight groups are registered with `nvim_set_hl` only
+once per unique color pair; subsequent renders reuse the cached group name.
+Parameters ~
+{buffer} `(ascii)`-ui.Buffer
+{dirty_rows} `(table<integer, boolean>)`  set of 0-indexed row numbers to refresh
+
+------------------------------------------------------------------------------
                                                                *Window:update()*
                            `Window:update`({buffer})
 Renders `buffer` into the Neovim window.
-Schedules a `vim.schedule` call that writes lines, applies highlights/colors,
-resizes the floating window to match the buffer dimensions and adjusts scroll.
-Errors if the window is not open.
+Only lines that changed since the last render are rewritten; extmarks are
+refreshed only for those rows. Resizes the floating window when dimensions
+change and adjusts scroll. Errors if the window is not open.
 Parameters ~
 {buffer} `(ascii)`-ui.Buffer
 

--- a/doc/tags
+++ b/doc/tags
@@ -10,6 +10,7 @@ Buffer:find_next_focusable()	ascii-ui.txt	/*Buffer:find_next_focusable()*
 Buffer:find_segment_by_id()	ascii-ui.txt	/*Buffer:find_segment_by_id()*
 Buffer:find_segment_by_position()	ascii-ui.txt	/*Buffer:find_segment_by_position()*
 Buffer:iter_colored_segments()	ascii-ui.txt	/*Buffer:iter_colored_segments()*
+Buffer:iter_colored_segments_on_lines()	ascii-ui.txt	/*Buffer:iter_colored_segments_on_lines()*
 Buffer:iter_focusables()	ascii-ui.txt	/*Buffer:iter_focusables()*
 Buffer:to_lines()	ascii-ui.txt	/*Buffer:to_lines()*
 Buffer:width()	ascii-ui.txt	/*Buffer:width()*
@@ -104,6 +105,7 @@ UserInteractions:interact()	ascii-ui.txt	/*UserInteractions:interact()*
 UserInteractions:new()	ascii-ui.txt	/*UserInteractions:new()*
 Window	ascii-ui.txt	/*Window*
 Window.new()	ascii-ui.txt	/*Window.new()*
+Window:_apply_highlights_for_rows()	ascii-ui.txt	/*Window:_apply_highlights_for_rows()*
 Window:close()	ascii-ui.txt	/*Window:close()*
 Window:disable_edits()	ascii-ui.txt	/*Window:disable_edits()*
 Window:enable_edits()	ascii-ui.txt	/*Window:enable_edits()*

--- a/lua/ascii-ui/buffer/buffer.lua
+++ b/lua/ascii-ui/buffer/buffer.lua
@@ -169,6 +169,43 @@ function Buffer:iter_colored_segments()
 	end
 end
 
+--- Like `iter_colored_segments` but only yields segments whose 0-indexed row
+--- is present in `dirty_rows`.  Avoids iterating unchanged lines entirely.
+---@param dirty_rows table<integer, boolean>  set of 0-indexed row numbers
+---@return fun(): ascii-ui.Buffer.SegmentFoundResult | nil
+function Buffer:iter_colored_segments_on_lines(dirty_rows)
+	local iter = vim.iter(self.lines)
+		:enumerate()
+		:filter(function(line_index, _)
+			return dirty_rows[line_index - 1] == true
+		end)
+		:map(function(line_index, line)
+			local col_offset = 1
+			return vim.iter(line.segments)
+				:map(function(segment)
+					local current_col = col_offset
+					col_offset = col_offset + segment:raw_len()
+					if segment:is_colored() then
+						return {
+							segment = segment,
+							position = { line = line_index, col = current_col },
+						}
+					else
+						return nil
+					end
+				end)
+				:filter(function(e)
+					return e ~= nil
+				end)
+				:totable()
+		end)
+		:flatten()
+
+	return function()
+		return iter:next()
+	end
+end
+
 ---@param lines string[]
 ---@return ascii-ui.Buffer
 function Buffer.from_lines(lines)

--- a/lua/ascii-ui/window/init.lua
+++ b/lua/ascii-ui/window/init.lua
@@ -100,6 +100,8 @@ function Window.new(opts)
 		ns_id = ns_id,
 		opts = opts,
 		edits_enabled = false,
+		_prev_buffer = nil,
+		_known_hl_groups = {},
 	}
 
 	setmetatable(state, Window)
@@ -208,10 +210,60 @@ function Window:close()
 	vim.api.nvim_set_option_value("modifiable", true, { buf = self.bufnr })
 end
 
+--- Applies highlight extmarks for all colored segments on a specific set of
+--- 0-indexed row numbers. Clears the namespace on those rows first so stale
+--- marks from a previous render are removed without touching unchanged rows.
+--- Anonymous color highlight groups are registered with `nvim_set_hl` only
+--- once per unique color pair; subsequent renders reuse the cached group name.
+---@param buffer ascii-ui.Buffer
+---@param dirty_rows table<integer, boolean>  set of 0-indexed row numbers to refresh
+function Window:_apply_highlights_for_rows(buffer, dirty_rows)
+	vim.api.nvim_set_option_value("winhl", ("Normal:%s"):format(highlights.DEFAULT), { win = self.winid })
+
+	-- clear only the rows we are about to rewrite
+	for row0 in pairs(dirty_rows) do
+		vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_id, row0, row0 + 1)
+	end
+
+	for segment_result in buffer:iter_colored_segments_on_lines(dirty_rows) do
+		local pos = segment_result.position
+		local row0 = pos.line - 1
+		local segment = segment_result.segment
+		local end_col = pos.col + segment:raw_len()
+
+		if segment.highlight then
+			vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_id, row0, pos.col - 1, {
+				end_col = end_col - 1,
+				strict = false,
+				hl_group = segment.highlight,
+			})
+		end
+
+		if segment.color then
+			local anonymous_group = (("AsciiUIAnonymousColor_fg%s_bg%s"):format(
+				segment.color.fg or "NONE",
+				segment.color.bg or "NONE"
+			)):gsub("#", "")
+
+			-- Register the highlight group only the first time we see this color pair.
+			if not self._known_hl_groups[anonymous_group] then
+				vim.api.nvim_set_hl(0, anonymous_group, { fg = segment.color.fg, bg = segment.color.bg })
+				self._known_hl_groups[anonymous_group] = true
+			end
+
+			vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_id, row0, pos.col - 1, {
+				end_col = end_col - 1,
+				strict = false,
+				hl_group = anonymous_group,
+			})
+		end
+	end
+end
+
 --- Renders `buffer` into the Neovim window.
---- Schedules a `vim.schedule` call that writes lines, applies highlights/colors,
---- resizes the floating window to match the buffer dimensions and adjusts scroll.
---- Errors if the window is not open.
+--- Only lines that changed since the last render are rewritten; extmarks are
+--- refreshed only for those rows. Resizes the floating window when dimensions
+--- change and adjusts scroll. Errors if the window is not open.
 ---@param buffer ascii-ui.Buffer
 function Window:update(buffer)
 	logger.debug("Updating window with id %s and bufnr %s", self.winid, self.bufnr)
@@ -220,11 +272,34 @@ function Window:update(buffer)
 		error("Window is not open")
 	end
 	vim.schedule(function()
-		-- buffer content
+		local prev = self._prev_buffer
+		local new_lines = buffer.lines
+		local prev_lines = prev and prev.lines or {}
+		local new_count = #new_lines
+		local prev_count = #prev_lines
+
+		-- Collect which 0-indexed rows need to be rewritten.
+		local dirty_rows = {} ---@type table<integer, boolean>
+
 		if not self.edits_enabled then
 			vim.api.nvim_set_option_value("modifiable", true, { buf = self.bufnr })
 		end
-		vim.api.nvim_buf_set_lines(self.bufnr, 0, -1, false, buffer:to_lines())
+
+		-- Rewrite rows that changed or are new.
+		for i = 1, new_count do
+			local row0 = i - 1
+			local new_str = new_lines[i]:to_string()
+			local prev_str = prev_lines[i] and prev_lines[i]:to_string() or nil
+			if new_str ~= prev_str then
+				vim.api.nvim_buf_set_lines(self.bufnr, row0, row0 + 1, false, { new_str })
+				dirty_rows[row0] = true
+			end
+		end
+
+		-- Remove rows that no longer exist (buffer shrank).
+		if prev_count > new_count then
+			vim.api.nvim_buf_set_lines(self.bufnr, new_count, -1, false, {})
+		end
 
 		if not self.edits_enabled then
 			vim.api.nvim_set_option_value("modifiable", false, { buf = self.bufnr })
@@ -235,6 +310,7 @@ function Window:update(buffer)
 			width = buffer:width(),
 			height = buffer:height(),
 		})
+
 		-- adjust scroll
 		vim.api.nvim_win_call(0, function()
 			local win = vim.api.nvim_get_current_win()
@@ -247,46 +323,19 @@ function Window:update(buffer)
 			Cursor.move_to(curpos, win)
 		end)
 
-		-- coloring
-		local function apply_highlight()
-			vim.api.nvim_buf_clear_namespace(self.bufnr, self.ns_id, 0, -1)
-
-			-- NOTE: Good for updating all the window
-			-- but unoptimal for just parts of the window or buffer
-			-- for that use: nvim_buf_set_extmark
-			vim.api.nvim_set_option_value("winhl", ("Normal:%s"):format(highlights.DEFAULT), { win = self.winid })
-
-			for segment_result in buffer:iter_colored_segments() do
-				local pos = segment_result.position
-				local segment = segment_result.segment
-				local end_col = pos.col + segment:raw_len()
-
-				if segment.highlight then
-					vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_id, pos.line - 1, pos.col - 1, {
-						end_col = end_col - 1,
-						strict = false,
-						hl_group = segment.highlight,
-					})
-				end
-
-				if segment.color then
-					local anonymous_group = (("AsciiUIAnonymousColor_fg%s_bg%s"):format(
-						segment.color.fg or "NONE",
-						segment.color.bg or "NONE"
-					)):gsub("#", "")
-
-					vim.api.nvim_set_hl(0, anonymous_group, { fg = segment.color.fg, bg = segment.color.bg })
-
-					vim.api.nvim_buf_set_extmark(self.bufnr, self.ns_id, pos.line - 1, pos.col - 1, {
-						end_col = end_col - 1,
-						strict = false,
-						hl_group = anonymous_group,
-					})
-				end
+		-- On the very first render there is no previous buffer: apply highlights
+		-- to all rows. On subsequent renders only touch dirty rows.
+		if not prev then
+			local all_rows = {}
+			for i = 1, new_count do
+				all_rows[i - 1] = true
 			end
+			self:_apply_highlights_for_rows(buffer, all_rows)
+		elseif next(dirty_rows) then
+			self:_apply_highlights_for_rows(buffer, dirty_rows)
 		end
 
-		apply_highlight()
+		self._prev_buffer = buffer
 	end)
 end
 


### PR DESCRIPTION
## Summary

- \`Window:update()\` now diffs the new buffer against the previous one line-by-line (via \`BufferLine:to_string()\`), calling \`nvim_buf_set_lines\` only for rows that actually changed
- \`nvim_buf_clear_namespace\` and extmark writes are scoped to dirty rows only — unchanged lines are never touched
- \`Buffer:iter_colored_segments_on_lines(dirty_rows)\` added to avoid iterating the full buffer when only a few lines changed
- Anonymous color highlight groups (\`AsciiUIAnonymousColor_*\`) are registered with \`nvim_set_hl\` only once per unique color pair per window instance, cached in \`_known_hl_groups\`

For a typical clock/counter UI where only one line changes per tick, this reduces the number of Neovim API calls from O(total lines + total colored segments) to O(1).