### PR TITLE
docs(codebase): translate Spanish comments to English

### DIFF
--- a/doc/ascii-ui.txt
+++ b/doc/ascii-ui.txt
@@ -286,11 +286,11 @@ Parameters ~
 ------------------------------------------------------------------------------
                                          *ascii-ui.components.createComponent()*
  `ascii-ui.components.createComponent`({name}, {functional_component}, {types})
-Crea un componente personalizado y lo registra
+Creates a custom component and registers it
 @generic ascii-ui.ComponentClosure, T
-@param name string Nombre del componente
+@param name string Component name
 @param functional_component fun(props: T): ascii-ui.FiberNode[]
-@param types? table<string, ascii-ui.PropsType> Tipos de los props del componente
+@param types? table<string, ascii-ui.PropsType> Component prop types
 @return ascii-ui.FunctionalComponent
 
 @overload fun(functional_component: ascii-ui.SimpleComponentFunction): ascii-ui.FunctionalComponent
@@ -489,7 +489,7 @@ Removes all registered listeners from every event type.
                                                          *ascii-ui.debugPrint()*
                    `ascii-ui.debugPrint`({fiber}, {print_fn})
 
-Debug: Imprime el árbol de Fibers con indentación y valores de hooks
+Debug: Prints the Fiber tree with indentation and hook values
 
 ------------------------------------------------------------------------------
                                                   *ascii-ui.reconcileChildren()*
@@ -522,7 +522,7 @@ Walks the parent chain of a fiber node and returns a path string like "Root > Ou
 ------------------------------------------------------------------------------
                                                            *ascii-ui.rerender()*
                           `ascii-ui.rerender`({root})
-Re-renderiza el árbol de fibers a partir de la raíz dada
+Re-renders the fiber tree from the given root
 @param root ascii-ui.RootFiberNode
 @return ascii-ui.RootFiberNode
 
@@ -1010,7 +1010,7 @@ Parameters ~
 ------------------------------------------------------------------------------
                                                   *ascii-ui.utils.generateKey()*
                       `ascii-ui.utils.generateKey`({tbl})
-Genera una clave única basada en una tabla
+Generates a unique key based on a table
 
 ------------------------------------------------------------------------------
                                                     *ascii-ui.utils.M.memoize()*
@@ -1071,7 +1071,7 @@ Type ~
 ------------------------------------------------------------------------------
                                                   *ascii-ui.utils.Metrics.get()*
                       `ascii-ui.utils.Metrics.get`({key})
-Devuelve el valor actual (0 si no existe).
+Returns the current value (0 if it does not exist).
 Parameters ~
 {key} `(string)`
 Return ~
@@ -1080,7 +1080,7 @@ Return ~
 ------------------------------------------------------------------------------
                                                   *ascii-ui.utils.Metrics.set()*
                   `ascii-ui.utils.Metrics.set`({key}, {value})
-Establece un valor exacto y lo devuelve.
+Sets an exact value and returns it.
 Parameters ~
 {key} `(string)`
 {value} `(number)`
@@ -1090,7 +1090,7 @@ Return ~
 ------------------------------------------------------------------------------
                                                   *ascii-ui.utils.Metrics.inc()*
                  `ascii-ui.utils.Metrics.inc`({key}, {amount})
-Incrementa (por defecto +1) y devuelve el nuevo total.
+Increments (default +1) and returns the new total.
 Parameters ~
 {key} `(string)`
 {amount} `(optional)` `(integer)`
@@ -1100,26 +1100,26 @@ Return ~
 ------------------------------------------------------------------------------
                                                 *ascii-ui.utils.Metrics.reset()*
                         `ascii-ui.utils.Metrics.reset`()
-Reinicia todo el almacén de métricas.
+Resets all metric storage.
 
 ------------------------------------------------------------------------------
                                                   *ascii-ui.utils.Metrics.all()*
                          `ascii-ui.utils.Metrics.all`()
-Devuelve una copia con todas las métricas.
+Returns a copy with all metrics.
 Return ~
 `(table<string, number>)` copy
 
 ------------------------------------------------------------------------------
                                                      *ascii-ui.utils.as_lines()*
                           `ascii-ui.utils.as_lines`()
-Convierte a líneas de texto para mostrar.
+Converts to text lines for display.
 Return ~
 `(string[])` lines
 
 ------------------------------------------------------------------------------
                                                  *ascii-ui.utils.Metrics.show()*
                      `ascii-ui.utils.Metrics.show`({opts})
-Muestra un popup muy simple con las métricas.
+Shows a very simple popup with the metrics.
 Parameters ~
 {opts} `(optional)` `(MetricsShowOpts)`
 Return ~

--- a/lua/ascii-ui/buffer/buffer.lua
+++ b/lua/ascii-ui/buffer/buffer.lua
@@ -150,7 +150,7 @@ function Buffer:iter_colored_segments()
 			return vim.iter(line.segments)
 				:map(function(segment)
 					local current_col = col_offset
-					col_offset = col_offset + segment:raw_len() -- o el método que dé el ancho
+					col_offset = col_offset + segment:raw_len() -- or the method that gives the width
 
 					if segment:is_colored() then
 						return {

--- a/lua/ascii-ui/components/create-component.lua
+++ b/lua/ascii-ui/components/create-component.lua
@@ -46,11 +46,11 @@ end
 -- - @generic P : table<string, any>
 --- @alias ascii-ui.FunctionalComponent<P> fun(props?: P): ascii-ui.FiberNode
 
---- Crea un componente personalizado y lo registra
+--- Creates a custom component and registers it
 --- @generic ascii-ui.ComponentClosure, T
---- @param name string Nombre del componente
+--- @param name string Component name
 --- @param functional_component fun(props: T): ascii-ui.FiberNode[]
---- @param types? table<string, ascii-ui.PropsType> Tipos de los props del componente
+--- @param types? table<string, ascii-ui.PropsType> Component prop types
 --- @return ascii-ui.FunctionalComponent
 ---
 --- @overload fun(functional_component: ascii-ui.SimpleComponentFunction): ascii-ui.FunctionalComponent
@@ -63,12 +63,12 @@ local function createComponent(name, functional_component, types)
 		opts.types = types or {}
 	end
 
-	-- Validar que el nombre sea único
+	-- Validate that the name is unique
 	if Renderer.component_tags[opts.name] then
 		logger.error(("El componente con nombre '%s' ya está registrado."):format(opts.name))
 	end
 
-	-- Generar la pseudofunción del componente
+	-- Generate the component's pseudo-function
 	local component_function = setmetatable({}, {
 		__is_a_component = true,
 		__call = function(_, ...)
@@ -81,7 +81,7 @@ local function createComponent(name, functional_component, types)
 				props = _args[1] or {}
 				validate_props(props, opts.types, opts.name)
 				function factory()
-					-- dentro del workLoop, currentFiber ya está seteado
+					-- inside the workLoop, currentFiber is already set
 					return function()
 						return opts.functional_component(props)
 					end

--- a/lua/ascii-ui/fiber.lua
+++ b/lua/ascii-ui/fiber.lua
@@ -6,16 +6,16 @@ local logger = require("ascii-ui.logger")
 local currentFiber
 
 ---
---- Debug: Imprime el árbol de Fibers con indentación y valores de hooks
+--- Debug: Prints the Fiber tree with indentation and hook values
 ---
 local function debugPrint(fiber, print_fn)
 	--- @param node ascii-ui.FiberNode
 	local function traverse(node, prefix, isLast)
 		local print = print_fn or logger.debug
-		-- Construye línea con prefijo gráfico
+		-- Builds line with graphic prefix
 		local branch = isLast and "└─ " or "├─ "
 		local line = prefix .. branch .. (node.type or "<buffer>")
-		-- Agrega estados de hooks si existen
+		-- Adds hook states if they exist
 		if node.hooks and #node.hooks > 0 then
 			local parts = {}
 			for _, h in ipairs(node.hooks) do
@@ -30,7 +30,7 @@ local function debugPrint(fiber, print_fn)
 			line = string.format("%s %s", line, node:get_line():to_string())
 		end
 		print(line)
-		-- Recorre hijos
+		-- Traverses children
 		local children = {}
 		local child = node.child
 		while child do
@@ -216,7 +216,7 @@ local function performUnitOfWork(fiber)
 	end
 end
 
--- recorre todos los Units of Work automáticamente
+-- Traverses all Units of Work automatically
 --- @param root ascii-ui.RootFiberNode
 local function workLoop(root)
 	local nextFiber = root
@@ -226,7 +226,7 @@ local function workLoop(root)
 	end
 end
 
--- helper de alto nivel: recibe un componente y devuelve las líneas del buffer
+-- High-level helper: receives a component and returns buffer lines
 --- @return ascii-ui.RootFiberNode
 local function render(Component)
 	logger.debug("📺 FIBER.RENDER")
@@ -237,7 +237,7 @@ local function render(Component)
 	return root
 end
 
---- Re-renderiza el árbol de fibers a partir de la raíz dada
+--- Re-renders the fiber tree from the given root
 --- @param root ascii-ui.RootFiberNode
 --- @return ascii-ui.RootFiberNode
 local function rerender(root)

--- a/lua/ascii-ui/fibernode.lua
+++ b/lua/ascii-ui/fibernode.lua
@@ -111,7 +111,7 @@ function FiberNode:is_same(other)
 		return false
 	end
 
-	-- para nodos hoja compara la línea renderizada
+	-- For leaf nodes, compares the rendered line
 	if
 		self:is_leaf()
 		--
@@ -395,7 +395,7 @@ end
 function FiberNode:unmount()
 	--- @param fiber ascii-ui.FiberNode
 	local function traverse(fiber)
-		-- 1) Primero descendemos a todos los hijos (post-order)
+		-- 1) First descend to all children (post-order)
 		local children = {}
 		local child = fiber.child
 		while child do
@@ -406,7 +406,7 @@ function FiberNode:unmount()
 			traverse(c)
 		end
 
-		-- 2) Luego ejecutamos los cleanups de este fiber en orden inverso (LIFO)
+		-- 2) Then execute this fiber's cleanups in reverse order (LIFO)
 		for i = #fiber.effects, 1, -1 do
 			local effect = fiber.effects[i]
 			effect.cleanup()

--- a/lua/ascii-ui/utils/memoize.lua
+++ b/lua/ascii-ui/utils/memoize.lua
@@ -1,11 +1,11 @@
 local M = {}
 
--- Tabla de caché global para todos los componentes
+-- Global cache table for all components
 local cache = {}
 
---- Genera una clave única basada en una tabla
+--- Generates a unique key based on a table
 local function generateKey(tbl)
-	return vim.inspect(tbl) -- Serializa las propiedades para generar una clave única
+	return vim.inspect(tbl) -- Serializes properties to generate a unique key
 end
 
 --- @param factory function

--- a/lua/ascii-ui/utils/metrics.lua
+++ b/lua/ascii-ui/utils/metrics.lua
@@ -36,18 +36,18 @@
 ---@field show fun(opts?: MetricsShowOpts): integer            # Opens a popup and returns the winid.
 local Metrics = {}
 
--- Almacenamiento en memoria
+-- In-memory storage
 ---@type MetricsStore
 local store = {}
 
---- Devuelve el valor actual (0 si no existe).
+--- Returns the current value (0 if it does not exist).
 ---@param key MetricsKey
 ---@return MetricsValue value
 function Metrics.get(key)
 	return store[key] or 0
 end
 
---- Establece un valor exacto y lo devuelve.
+--- Sets an exact value and returns it.
 ---@param key MetricsKey
 ---@param value MetricsValue
 ---@return MetricsValue new_value
@@ -56,7 +56,7 @@ function Metrics.set(key, value)
 	return store[key]
 end
 
---- Incrementa (por defecto +1) y devuelve el nuevo total.
+--- Increments (default +1) and returns the new total.
 ---@param key MetricsKey
 ---@param amount? integer
 ---@return MetricsValue new_total
@@ -66,12 +66,12 @@ function Metrics.inc(key, amount)
 	return store[key]
 end
 
---- Reinicia todo el almacén de métricas.
+--- Resets all metric storage.
 function Metrics.reset()
 	store = {}
 end
 
---- Devuelve una copia con todas las métricas.
+--- Returns a copy with all metrics.
 ---@return MetricsStore copy
 function Metrics.all()
 	local out = {}
@@ -81,11 +81,11 @@ function Metrics.all()
 	return out
 end
 
---- Convierte a líneas de texto para mostrar.
+--- Converts to text lines for display.
 ---@return string[] lines
 local function as_lines()
 	local lines = { "# Metrics" }
-	-- Orden alfabético para que sea estable
+	-- Alphabetical order for stability
 	local keys = {}
 	for k in pairs(store) do
 		table.insert(keys, k)
@@ -100,7 +100,7 @@ local function as_lines()
 	return lines
 end
 
---- Muestra un popup muy simple con las métricas.
+--- Shows a very simple popup with the metrics.
 ---@param opts? MetricsShowOpts
 ---@return integer winid
 function Metrics.show(opts)
@@ -126,7 +126,7 @@ function Metrics.show(opts)
 		border = opts.border or "rounded",
 	})
 
-	-- Cerrar con q o <Esc>
+	-- Close with q or <Esc>
 	local function close()
 		if vim.api.nvim_win_is_valid(win) then
 			vim.api.nvim_win_close(win, true)
@@ -135,7 +135,7 @@ function Metrics.show(opts)
 	vim.keymap.set("n", "q", close, { buffer = buf, nowait = true, silent = true })
 	vim.keymap.set("n", "<Esc>", close, { buffer = buf, nowait = true, silent = true })
 
-	-- Resalta el título si existe 'Title'
+	-- Highlights the title if 'Title' exists
 	pcall(vim.api.nvim_buf_add_highlight, buf, -1, "Title", 0, 0, -1)
 
 	return win

--- a/lua/ascii-ui/utils/strict_throttle.lua
+++ b/lua/ascii-ui/utils/strict_throttle.lua
@@ -9,7 +9,7 @@ local function strict_throttle(fn, delay)
 			if queued_args then
 				local args = queued_args
 				queued_args = nil
-				run(unpack(args)) -- <-- reinicia delay aquí
+				run(unpack(args)) -- <-- restarts delay here
 			else
 				running = false
 			end


### PR DESCRIPTION
## Summary

Translate all Spanish comments to English across 7 source files.

### Files changed

- `lua/ascii-ui/fiber.lua`
- `lua/ascii-ui/fibernode.lua`
- `lua/ascii-ui/components/create-component.lua`
- `lua/ascii-ui/utils/memoize.lua`
- `lua/ascii-ui/utils/metrics.lua`
- `lua/ascii-ui/utils/strict_throttle.lua`
- `lua/ascii-ui/buffer/buffer.lua`

### Verification

- [x] `make check` passes
- [x] `make test` passes
- [x] No code changes, only comment translations

Related to #61 (item 5)

[agent: ascii-ui-dev]