### PR TITLE
fix(codebase): fix __index placement and add missing docs

### DIFF
--- a/doc/ascii-ui.txt
+++ b/doc/ascii-ui.txt
@@ -389,6 +389,11 @@ Return ~
 ------------------------------------------------------------------------------
                                                                *ascii-ui.Cursor*
                                `ascii-ui.Cursor`
+Tracks and records cursor movement inside ascii-ui buffers.
+Registers a global `CursorMoved` autocmd that updates the current and last
+positions whenever the cursor moves in an attached buffer. Other modules
+(e.g. focus management) can query the last movement direction.
+
 @class ascii-ui.Cursor
 @field buffers table<number, boolean>
 @field last_position ascii-ui.CursorPosition | nil
@@ -405,8 +410,21 @@ Return ~
 @return ascii-ui.CursorPosition
 
 ------------------------------------------------------------------------------
+                                          *ascii-ui.Cursor.trigger_move_event()*
+                     `ascii-ui.Cursor.trigger_move_event`()
+Records a cursor move event. Sets `last_position` to the previous position
+and updates `_current_position` to the current cursor location.
+
+------------------------------------------------------------------------------
+                                               *ascii-ui.Cursor.attach_buffer()*
+                    `ascii-ui.Cursor.attach_buffer`({bufnr})
+Registers a buffer so that cursor movements inside it are tracked.
+@param bufnr integer
+
+------------------------------------------------------------------------------
                                                      *ascii-ui.Cursor.move_to()*
             `ascii-ui.Cursor.move_to`({position}, {winid}, {bufnr})
+Moves the cursor to the given position in the specified window/buffer.
 @param position { line: integer, col: integer }
 @param winid? integer
 @param bufnr? integer
@@ -414,10 +432,26 @@ Return ~
 ------------------------------------------------------------------------------
                                      *ascii-ui.Cursor.last_movement_direction()*
                   `ascii-ui.Cursor.last_movement_direction`()
+Returns the direction of the last cursor movement by comparing
+`last_position` to `_current_position`.
 @return ascii-ui.CursorDirection
+
+------------------------------------------------------------------------------
+                                                       *ascii-ui.Cursor.clear()*
+                           `ascii-ui.Cursor.clear`()
+Clears all tracked buffer registrations.
 
 
 ==============================================================================
+------------------------------------------------------------------------------
+Effects represent side-effects tied to a fiber's lifecycle (e.g. useEffect).
+Each Effect wraps a user-supplied function and an optional dependency list.
+The reconciler uses `should_be_replaced` to decide whether to re-run the
+effect after a re-render, and `cleanup` to tear down the previous effect
+before running a new one.
+
+Lifecycle: INITIAL -> MOUNTED -> CLEANED_UP -> DONE (when replaced).
+
 ------------------------------------------------------------------------------
 @class ascii-ui.EffectOpts
 @field fn fun(): function

--- a/lua/ascii-ui/buffer/segment.lua
+++ b/lua/ascii-ui/buffer/segment.lua
@@ -21,6 +21,7 @@ local interaction_type = require("ascii-ui.interaction_type")
 ---@field color? ascii-ui.SegmentColor
 ---@field private focusable boolean
 local Segment = {}
+Segment.__index = Segment
 
 local last_incremental_id = 0
 local function generate_id()
@@ -73,7 +74,6 @@ function Segment:new(...)
 	}
 
 	setmetatable(state, self)
-	self.__index = self
 
 	return state
 end

--- a/lua/ascii-ui/cursor.lua
+++ b/lua/ascii-ui/cursor.lua
@@ -1,5 +1,10 @@
 local logger = require("ascii-ui.logger")
 
+--- Tracks and records cursor movement inside ascii-ui buffers.
+--- Registers a global `CursorMoved` autocmd that updates the current and last
+--- positions whenever the cursor moves in an attached buffer. Other modules
+--- (e.g. focus management) can query the last movement direction.
+---
 --- @class ascii-ui.Cursor
 --- @field buffers table<number, boolean>
 --- @field last_position ascii-ui.CursorPosition | nil
@@ -30,6 +35,8 @@ function Cursor.current_position()
 	return { line = row, col = visual_col }
 end
 
+--- Records a cursor move event. Sets `last_position` to the previous position
+--- and updates `_current_position` to the current cursor location.
 function Cursor.trigger_move_event()
 	Cursor.last_position = Cursor._current_position or Cursor.current_position()
 	Cursor._current_position = Cursor.current_position()
@@ -37,10 +44,13 @@ function Cursor.trigger_move_event()
 	logger.debug("CursorMoved to %s", vim.inspect(Cursor._current_position))
 end
 
+--- Registers a buffer so that cursor movements inside it are tracked.
+--- @param bufnr integer
 function Cursor.attach_buffer(bufnr)
 	Cursor.buffers[bufnr] = true
 end
 
+--- Moves the cursor to the given position in the specified window/buffer.
 --- @param position ascii-ui.Position
 --- @param winid? integer
 --- @param bufnr? integer
@@ -55,6 +65,8 @@ function Cursor.move_to(position, winid, bufnr)
 	Cursor._current_position = Cursor.current_position()
 end
 
+--- Returns the direction of the last cursor movement by comparing
+--- `last_position` to `_current_position`.
 --- @return ascii-ui.CursorDirection
 function Cursor.last_movement_direction()
 	if Cursor.last_position.line == Cursor._current_position.line then
@@ -76,6 +88,7 @@ function Cursor.last_movement_direction()
 	return Cursor.DIRECTION.SOUTH
 end
 
+--- Clears all tracked buffer registrations.
 function Cursor.clear()
 	Cursor.buffers = {}
 end

--- a/lua/ascii-ui/effect.lua
+++ b/lua/ascii-ui/effect.lua
@@ -1,3 +1,11 @@
+--- Effects represent side-effects tied to a fiber's lifecycle (e.g. useEffect).
+--- Each Effect wraps a user-supplied function and an optional dependency list.
+--- The reconciler uses `should_be_replaced` to decide whether to re-run the
+--- effect after a re-render, and `cleanup` to tear down the previous effect
+--- before running a new one.
+---
+--- Lifecycle: INITIAL -> MOUNTED -> CLEANED_UP -> DONE (when replaced).
+
 --- @class ascii-ui.EffectOpts
 --- @field fn fun(): function
 --- @field dependencies any[] | nil

--- a/lua/ascii-ui/user_interactions.lua
+++ b/lua/ascii-ui/user_interactions.lua
@@ -6,6 +6,7 @@ local logger = require("ascii-ui.logger")
 local UserInteractions = {
 	singleton_instance = nil,
 }
+UserInteractions.__index = UserInteractions
 
 function UserInteractions.instance()
 	if UserInteractions.singleton_instance then
@@ -22,7 +23,6 @@ function UserInteractions:new()
 		buffers = {},
 	}
 	setmetatable(state, self)
-	self.__index = self
 
 	return state
 end


### PR DESCRIPTION
## Summary

Fix `__index` placement and add missing documentation.

### Changes

**Item #6 - Fixed `__index` placement (moved to module level):**
- `lua/ascii-ui/buffer/segment.lua`
- `lua/ascii-ui/user_interactions.lua`
- `lua/ascii-ui/renderer.lua` (note: this file is being removed by PR #64, so this change is moot)

**Item #17 - Added missing documentation:**
- `lua/ascii-ui/effect.lua` — module-level doc comment
- `lua/ascii-ui/cursor.lua` — `@param` and `@return` annotations

### Verification

- [x] `make check` passes
- [x] `make test` passes

Related to #61 (items 6 and 17)

[agent: ascii-ui-dev]