### PR TITLE
feat(utils): add informative error handling for render failures

### DIFF
--- a/doc/ascii-ui.txt
+++ b/doc/ascii-ui.txt
@@ -647,17 +647,17 @@ Removes all registered listeners from every event type.
 Debug: Prints the Fiber tree with indentation and hook values
 
 ------------------------------------------------------------------------------
-                                                  *ascii-ui.reconcileChildren()*
-             `ascii-ui.reconcileChildren`({parent}, {new_children})
-@param parent ascii-ui.FiberNode
-@param new_children ascii-ui.FiberNode[]
-
-------------------------------------------------------------------------------
                                                       *ascii-ui.componentPath()*
                         `ascii-ui.componentPath`({node})
 Walks the parent chain of a fiber node and returns a path string like "Root > Outer > Inner"
 @param node ascii-ui.FiberNode
 @return string
+
+------------------------------------------------------------------------------
+                                                  *ascii-ui.reconcileChildren()*
+             `ascii-ui.reconcileChildren`({parent}, {new_children})
+@param parent ascii-ui.FiberNode
+@param new_children ascii-ui.FiberNode[]
 
 ------------------------------------------------------------------------------
                                                   *ascii-ui.performUnitOfWork()*
@@ -1063,6 +1063,12 @@ the component automatically (live-reload).
 
 ==============================================================================
 ------------------------------------------------------------------------------
+                                                *ascii-ui.render_error_buffer()*
+                     `ascii-ui.render_error_buffer`({err})
+@param err ascii-ui.Error
+@return ascii-ui.Buffer
+
+------------------------------------------------------------------------------
 Mounts a root component into a viewport and starts the render loop.
 
 The simplest call opens a centered Neovim floating window automatically:
@@ -1336,6 +1342,66 @@ Parameters ~
              `ascii-ui.UserInteractions:detach_buffer`({buffer_id})
 Parameters ~
 {buffer_id} `(integer)`
+
+
+==============================================================================
+------------------------------------------------------------------------------
+Error handling utilities for ascii-ui.
+Provides consistent error formatting and display for render failures.
+
+@module "ascii-ui.utils.error_handler"
+
+------------------------------------------------------------------------------
+@alias ascii-ui.ErrorType
+| "render"      # Error during component render
+| "hook"        # Error in a hook (useState, useEffect, etc.)
+| "effect"      # Error in an effect or cleanup
+| "interaction" # Error in user interaction handler
+| "viewport"    # Error in viewport operations
+
+------------------------------------------------------------------------------
+@class ascii-ui.Error
+@field err_type ascii-ui.ErrorType
+@field component_path string
+@field message string
+
+------------------------------------------------------------------------------
+                                                          *ascii-ui.utils.HINTS*
+                             `ascii-ui.utils.HINTS`
+Hints for each error type to help users understand what went wrong.
+@type table<ascii-ui.ErrorType, string>
+
+------------------------------------------------------------------------------
+                                                 *ascii-ui.utils.format_error()*
+     `ascii-ui.utils.format_error`({err_type}, {component_path}, {message})
+Formats an error with consistent structure.
+@param err_type ascii-ui.ErrorType
+@param component_path string | nil
+@param message string
+@return string formatted_error
+
+------------------------------------------------------------------------------
+                                                 *ascii-ui.utils.create_error()*
+     `ascii-ui.utils.create_error`({err_type}, {component_path}, {message})
+Creates an error table with structured information.
+@param err_type ascii-ui.ErrorType
+@param component_path string | nil
+@param message string
+@return ascii-ui.Error
+
+------------------------------------------------------------------------------
+                                                     *ascii-ui.utils.get_hint()*
+                     `ascii-ui.utils.get_hint`({err_type})
+Gets a helpful hint for an error type.
+@param err_type ascii-ui.ErrorType
+@return string hint
+
+------------------------------------------------------------------------------
+                                        *ascii-ui.utils.render_error_to_lines()*
+                 `ascii-ui.utils.render_error_to_lines`({err})
+Converts an error into displayable lines for the viewport.
+@param err ascii-ui.Error
+@return string[] lines
 
 
 ==============================================================================

--- a/lua/ascii-ui/fiber.lua
+++ b/lua/ascii-ui/fiber.lua
@@ -1,4 +1,5 @@
 local FiberNode = require("ascii-ui.fibernode")
+local error_handler = require("ascii-ui.utils.error_handler")
 
 local logger = require("ascii-ui.logger")
 
@@ -46,17 +47,47 @@ local function debugPrint(fiber, print_fn)
 	traverse(fiber, "", true)
 end
 
+--- Walks the parent chain of a fiber node and returns a path string like "Root > Outer > Inner"
+--- @param node ascii-ui.FiberNode
+--- @return string
+local function componentPath(node)
+	local parts = {}
+	local current = node
+	while current do
+		if current.type then
+			table.insert(parts, 1, current.type)
+		end
+		current = current.parent
+	end
+	return table.concat(parts, " > ")
+end
+
 --- @param parent ascii-ui.FiberNode
 --- @param new_children ascii-ui.FiberNode[]
 local function reconcileChildren(parent, new_children)
-	assert(type(new_children) == "table", "new_children should be a table, got: " .. type(new_children))
-	assert(
-		--- @param node ascii-ui.FiberNode
-		vim.iter(new_children):all(function(node)
-			return FiberNode.is_node(node)
-		end),
-		"cannot reconcile parent with objects that are not FiberNodes. Found:" .. vim.inspect(new_children)
-	)
+	if type(new_children) ~= "table" then
+		local path = componentPath(parent)
+		local err = error_handler.create_error(
+			"render",
+			path,
+			string.format("expected list of FiberNode/BufferLine, got %s", type(new_children))
+		)
+		error(error_handler.format_error(err.err_type, err.component_path, err.message), 0)
+	end
+
+	local all_nodes = vim.iter(new_children):all(function(node)
+		return FiberNode.is_node(node)
+	end)
+
+	if not all_nodes then
+		local path = componentPath(parent)
+		local err = error_handler.create_error(
+			"render",
+			path,
+			"expected list of FiberNode/BufferLine, got non-FiberNode values"
+		)
+		error(error_handler.format_error(err.err_type, err.component_path, err.message), 0)
+	end
 
 	logger.debug(
 		"🧑‍🧑‍🧒‍🧒🧑‍🧑‍🧒‍🧒🧑‍🧑‍🧒‍🧒 Reconciling children of %s",
@@ -104,21 +135,6 @@ local function reconcileChildren(parent, new_children)
 	end
 end
 
---- Walks the parent chain of a fiber node and returns a path string like "Root > Outer > Inner"
---- @param node ascii-ui.FiberNode
---- @return string
-local function componentPath(node)
-	local parts = {}
-	local current = node
-	while current do
-		if current.type then
-			table.insert(parts, 1, current.type)
-		end
-		current = current.parent
-	end
-	return table.concat(parts, " > ")
-end
-
 --- @param fiber ascii-ui.RootFiberNode
 local function performUnitOfWork(fiber)
 	if fiber.tag == "NONE" then
@@ -138,7 +154,8 @@ local function performUnitOfWork(fiber)
 			return fiber:unwrap_closure()
 		end, function(err)
 			local path = componentPath(fiber)
-			return string.format("component error [%s]: %s", path, err)
+			local error_obj = error_handler.create_error("render", path, err)
+			return error_handler.format_error(error_obj.err_type, error_obj.component_path, error_obj.message)
 		end)
 
 		if not ok then
@@ -146,7 +163,15 @@ local function performUnitOfWork(fiber)
 		end
 
 		local new_children = result
-		assert(FiberNode.is_node_list(new_children), "Expected FiberNode. Found: " .. vim.inspect(new_children))
+		if not FiberNode.is_node_list(new_children) then
+			local path = componentPath(fiber)
+			local err = error_handler.create_error(
+				"render",
+				path,
+				string.format("expected list of FiberNode/BufferLine, got %s", type(new_children))
+			)
+			error(error_handler.format_error(err.err_type, err.component_path, err.message), 0)
+		end
 		local old_child = fiber.output and fiber.output or {}
 		local new_child = new_children[1]
 

--- a/lua/ascii-ui/fibernode.lua
+++ b/lua/ascii-ui/fibernode.lua
@@ -1,5 +1,6 @@
 local Buffer = require("ascii-ui.buffer.buffer")
 local Bufferline = require("ascii-ui.buffer.bufferline")
+local error_handler = require("ascii-ui.utils.error_handler")
 local is_callable = require("ascii-ui.utils.is_callable")
 local logger = require("ascii-ui.logger")
 local props_are_equal = require("ascii-ui.utils.props_are_equal")
@@ -232,6 +233,18 @@ function FiberNode:unwrap_closure()
 	end
 
 	-- assert(FiberNode.is_node(output), "Fibernode.closure should return a FiberNode. Found " .. vim.inspect(output))
+
+	-- Validate that output is a table before flattening
+	if type(output) ~= "table" then
+		error(
+			string.format(
+				"Component must return a list (table) of FiberNode or BufferLine objects, got %s",
+				type(output)
+			),
+			0
+		)
+	end
+
 	output = flatten(output)
 
 	return vim.iter(output)
@@ -340,7 +353,8 @@ function FiberNode:run_pending()
 
 	local function wrap_call(fn, kind)
 		local ok, err = xpcall(fn, function(e)
-			return string.format("effect error in <%s> [%s]: %s", component_name, kind, e)
+			local err_obj = error_handler.create_error("effect", component_name, string.format("[%s] %s", kind, e))
+			return error_handler.format_error(err_obj.err_type, err_obj.component_path, err_obj.message)
 		end)
 		if not ok then
 			error(err, 0)

--- a/lua/ascii-ui/mount.lua
+++ b/lua/ascii-ui/mount.lua
@@ -1,7 +1,10 @@
 local Buffer = require("ascii-ui.buffer.buffer")
+local BufferLine = require("ascii-ui.buffer.bufferline")
 local Cursor = require("ascii-ui.cursor")
 local EventBus = require("ascii-ui.events")
+local Segment = require("ascii-ui.buffer.segment")
 local Window = require("ascii-ui.window")
+local error_handler = require("ascii-ui.utils.error_handler")
 local i = require("ascii-ui.interaction_type")
 local logger = require("ascii-ui.logger")
 local user_interations = require("ascii-ui.user_interactions")
@@ -10,6 +13,17 @@ local fiber = require("ascii-ui.fiber")
 local render = fiber.render
 local rerender = fiber.rerender
 local is_callable = require("ascii-ui.utils.is_callable")
+
+--- @param err ascii-ui.Error
+--- @return ascii-ui.Buffer
+local function render_error_buffer(err)
+	local lines = error_handler.render_error_to_lines(err)
+	local buffer = Buffer.new()
+	for _, line in ipairs(lines) do
+		buffer:add(BufferLine.new(Segment:new({ content = line, color = { fg = "#ff0000" } })))
+	end
+	return buffer
+end
 
 --- Mounts a root component into a viewport and starts the render loop.
 ---
@@ -62,11 +76,44 @@ return function(RootComponent, viewport)
 	-- create an isolated event bus for this mount
 	local bus = EventBus.new()
 
-	-- does first render
-	local fiberRoot = render(RootComponent)
+	-- does first render with error handling
+	local fiberRoot, rendered_buffer
+	local render_ok, render_err = xpcall(function()
+		fiberRoot = render(RootComponent)
+		return fiberRoot:get_buffer()
+	end, function(err)
+		-- Parse error message to extract component path and message
+		local err_type = "render"
+		local component_path = "unknown"
+		local message = tostring(err)
+
+		-- Try to parse the error format: [type] in <path>: message
+		local parsed_type, parsed_path, parsed_msg = err:match("^%[([^%]]+)%] in <([^>]+)>: (.+)$")
+		if parsed_type then
+			err_type = parsed_type
+			component_path = parsed_path
+			message = parsed_msg
+		end
+
+		return error_handler.create_error(err_type, component_path, message)
+	end)
+
+	if not render_ok then
+		-- Render error to viewport
+		local error_buffer = render_error_buffer(render_err)
+		local window = viewport or Window.new({ width = error_buffer:width(), height = error_buffer:height() })
+		window:open()
+		window:update(error_buffer)
+		logger.error("Render error: %s", vim.inspect(render_err))
+		return window:get_bufnr()
+	end
+
+	rendered_buffer = render_err -- render_err contains the buffer from the xpcall success
+
 	-- inject the bus so hooks (use_state) can trigger state_change on this instance only
 	fiberRoot.bus = bus
-	local rendered_buffer = fiberRoot:get_buffer()
+
+	fiber.debugPrint(fiberRoot, logger.debug)
 
 	fiber.debugPrint(fiberRoot, logger.debug)
 
@@ -85,10 +132,36 @@ return function(RootComponent, viewport)
 
 		logger.info("Rerendering on state change for window %d and buffer %d", window:get_id(), window:get_bufnr())
 		local current_lines_count = rendered_buffer:height()
-		fiberRoot = rerender(fiberRoot)
+
+		local rerender_ok, rerender_result = xpcall(function()
+			fiberRoot = rerender(fiberRoot)
+			return fiberRoot:get_buffer()
+		end, function(err)
+			local err_type = "render"
+			local component_path = "unknown"
+			local message = tostring(err)
+
+			local parsed_type, parsed_path, parsed_msg = err:match("^%[([^%]]+)%] in <([^>]+)>: (.+)$")
+			if parsed_type then
+				err_type = parsed_type
+				component_path = parsed_path
+				message = parsed_msg
+			end
+
+			return error_handler.create_error(err_type, component_path, message)
+		end)
+
+		if not rerender_ok then
+			-- Render error to viewport
+			local error_buffer = render_error_buffer(rerender_result)
+			window:update(error_buffer)
+			logger.error("Rerender error: %s", vim.inspect(rerender_result))
+			return
+		end
+
 		fiberRoot.bus = bus
+		rendered_buffer = rerender_result
 		fiber.debugPrint(fiberRoot, logger.debug)
-		rendered_buffer = fiberRoot:get_buffer()
 		local new_lines_count = rendered_buffer:height()
 		window:update(rendered_buffer)
 

--- a/lua/ascii-ui/utils/error_handler.lua
+++ b/lua/ascii-ui/utils/error_handler.lua
@@ -1,0 +1,118 @@
+--- Error handling utilities for ascii-ui.
+--- Provides consistent error formatting and display for render failures.
+---
+--- @module "ascii-ui.utils.error_handler"
+
+--- @alias ascii-ui.ErrorType
+--- | "render"      # Error during component render
+--- | "hook"        # Error in a hook (useState, useEffect, etc.)
+--- | "effect"      # Error in an effect or cleanup
+--- | "interaction" # Error in user interaction handler
+--- | "viewport"    # Error in viewport operations
+
+--- @class ascii-ui.Error
+--- @field err_type ascii-ui.ErrorType
+--- @field component_path string
+--- @field message string
+
+local error_handler = {}
+
+--- Hints for each error type to help users understand what went wrong.
+--- @type table<ascii-ui.ErrorType, string>
+local HINTS = {
+	render = "Components must return a list (table) of FiberNode or BufferLine objects.\n"
+		.. "      Did you forget to wrap your return value?\n"
+		.. "      \n"
+		.. "      Example:\n"
+		.. '        return { Segment:new({ content = "hello" }):wrap() }',
+	hook = "Hooks (useState, useEffect, useReducer) must be called during component render.\n"
+		.. "      They cannot be called inside callbacks, effects, or conditionally.\n"
+		.. "      \n"
+		.. "      Rules:\n"
+		.. "        - Only call hooks at the top level of your component\n"
+		.. "        - Don't call hooks inside loops, conditions, or nested functions",
+	effect = "Effects run after render and should not throw errors.\n"
+		.. "      Check your useEffect cleanup functions and effect logic.\n"
+		.. "      \n"
+		.. "      Common causes:\n"
+		.. "        - Accessing nil values\n"
+		.. "        - Calling APIs that don't exist\n"
+		.. "        - Cleanup function errors",
+	interaction = "User interaction handlers (on_press, on_select, etc.) should not throw.\n"
+		.. "      Add error handling to your callbacks.\n"
+		.. "      \n"
+		.. "      Example:\n"
+		.. "        on_press = function()\n"
+		.. "          local ok, err = pcall(function() ... end)\n"
+		.. "          if not ok then log(err) end\n"
+		.. "        end",
+	viewport = "Viewport operations (open, update, close) failed.\n"
+		.. "      This may be a Neovim API issue or invalid window state.\n"
+		.. "      \n"
+		.. "      Check:\n"
+		.. "        - Window/buffer validity\n"
+		.. "        - Neovim API permissions\n"
+		.. "        - Floating window configuration",
+}
+
+--- Formats an error with consistent structure.
+--- @param err_type ascii-ui.ErrorType
+--- @param component_path string | nil
+--- @param message string
+--- @return string formatted_error
+function error_handler.format_error(err_type, component_path, message)
+	local path = component_path
+	if not path or path == "" then
+		path = "unknown"
+	end
+	return string.format("[%s] in <%s>: %s", err_type, path, message)
+end
+
+--- Creates an error table with structured information.
+--- @param err_type ascii-ui.ErrorType
+--- @param component_path string | nil
+--- @param message string
+--- @return ascii-ui.Error
+function error_handler.create_error(err_type, component_path, message)
+	return {
+		err_type = err_type,
+		component_path = component_path or "unknown",
+		message = message,
+	}
+end
+
+--- Gets a helpful hint for an error type.
+--- @param err_type ascii-ui.ErrorType
+--- @return string hint
+function error_handler.get_hint(err_type)
+	return HINTS[err_type] or "An unexpected error occurred. Check the component code for issues."
+end
+
+--- Converts an error into displayable lines for the viewport.
+--- @param err ascii-ui.Error
+--- @return string[] lines
+function error_handler.render_error_to_lines(err)
+	local lines = {}
+	local hint = error_handler.get_hint(err.err_type)
+
+	-- Header
+	table.insert(lines, "═══ RENDER ERROR ═══")
+	table.insert(lines, "")
+
+	-- Error details
+	table.insert(lines, "Type: " .. err.err_type)
+	table.insert(lines, "Component: " .. err.component_path)
+	table.insert(lines, "Message: " .. err.message)
+	table.insert(lines, "")
+
+	-- Hint
+	table.insert(lines, "Hint: " .. hint)
+	table.insert(lines, "")
+
+	-- Footer
+	table.insert(lines, "═══════════════════")
+
+	return lines
+end
+
+return error_handler

--- a/tests/unit/error_handler_spec.lua
+++ b/tests/unit/error_handler_spec.lua
@@ -1,0 +1,186 @@
+pcall(require, "luacov")
+---@module "luassert"
+
+local error_handler = require("ascii-ui.utils.error_handler")
+
+describe("error_handler", function()
+	describe("format_error", function()
+		it("formats a render error with component path", function()
+			local err = error_handler.format_error("render", "Root > App > MenuItem", "expected list, got string")
+			assert.are.equal("[render] in <Root > App > MenuItem>: expected list, got string", err)
+		end)
+
+		it("formats a hook error", function()
+			local err = error_handler.format_error("hook", "App > Sidebar", "useState called outside render")
+			assert.are.equal("[hook] in <App > Sidebar>: useState called outside render", err)
+		end)
+
+		it("formats an effect error", function()
+			local err = error_handler.format_error("effect", "Button", "effect exploded")
+			assert.are.equal("[effect] in <Button>: effect exploded", err)
+		end)
+
+		it("formats an interaction error", function()
+			local err = error_handler.format_error("interaction", "Select", "on_select failed")
+			assert.are.equal("[interaction] in <Select>: on_select failed", err)
+		end)
+
+		it("formats a viewport error", function()
+			local err = error_handler.format_error("viewport", "Root", "window creation failed")
+			assert.are.equal("[viewport] in <Root>: window creation failed", err)
+		end)
+
+		it("handles nil component path gracefully", function()
+			local err = error_handler.format_error("render", nil, "something broke")
+			assert.are.equal("[render] in <unknown>: something broke", err)
+		end)
+
+		it("handles empty component path", function()
+			local err = error_handler.format_error("render", "", "something broke")
+			assert.are.equal("[render] in <unknown>: something broke", err)
+		end)
+	end)
+
+	describe("render_error_to_lines", function()
+		it("returns a table of strings", function()
+			local err = {
+				err_type = "render",
+				component_path = "Root > App",
+				message = "expected list, got string",
+			}
+			local lines = error_handler.render_error_to_lines(err)
+			assert.are.same("table", type(lines))
+			assert.is_true(#lines > 0)
+		end)
+
+		it("includes error header", function()
+			local err = {
+				err_type = "render",
+				component_path = "Root > App",
+				message = "test error",
+			}
+			local lines = error_handler.render_error_to_lines(err)
+			local joined = table.concat(lines, "\n")
+			assert.truthy(joined:find("RENDER ERROR"))
+		end)
+
+		it("includes error type", function()
+			local err = {
+				err_type = "hook",
+				component_path = "App",
+				message = "hook failed",
+			}
+			local lines = error_handler.render_error_to_lines(err)
+			local joined = table.concat(lines, "\n")
+			assert.truthy(joined:find("Type: hook"))
+		end)
+
+		it("includes component path", function()
+			local err = {
+				err_type = "render",
+				component_path = "Root > App > MenuItem",
+				message = "test error",
+			}
+			local lines = error_handler.render_error_to_lines(err)
+			local joined = table.concat(lines, "\n")
+			assert.truthy(joined:find("Component: Root > App > MenuItem"))
+		end)
+
+		it("includes error message", function()
+			local err = {
+				err_type = "render",
+				component_path = "App",
+				message = "something went wrong",
+			}
+			local lines = error_handler.render_error_to_lines(err)
+			local joined = table.concat(lines, "\n")
+			assert.truthy(joined:find("Message: something went wrong"))
+		end)
+
+		it("includes hint for render errors", function()
+			local err = {
+				err_type = "render",
+				component_path = "App",
+				message = "expected list, got string",
+			}
+			local lines = error_handler.render_error_to_lines(err)
+			local joined = table.concat(lines, "\n")
+			assert.truthy(joined:find("Hint:"))
+		end)
+
+		it("includes hint for hook errors", function()
+			local err = {
+				err_type = "hook",
+				component_path = "App",
+				message = "useState called outside render",
+			}
+			local lines = error_handler.render_error_to_lines(err)
+			local joined = table.concat(lines, "\n")
+			assert.truthy(joined:find("Hint:"))
+		end)
+
+		it("includes closing border", function()
+			local err = {
+				err_type = "render",
+				component_path = "App",
+				message = "test",
+			}
+			local lines = error_handler.render_error_to_lines(err)
+			local last_line = lines[#lines]
+			assert.truthy(last_line:find("═"))
+		end)
+	end)
+
+	describe("create_error", function()
+		it("creates an error table with all fields", function()
+			local err = error_handler.create_error("render", "Root > App", "test message")
+			assert.are.equal("render", err.err_type)
+			assert.are.equal("Root > App", err.component_path)
+			assert.are.equal("test message", err.message)
+		end)
+
+		it("handles nil component path", function()
+			local err = error_handler.create_error("render", nil, "test")
+			assert.are.equal("unknown", err.component_path)
+		end)
+	end)
+
+	describe("get_hint", function()
+		it("returns hint for render errors", function()
+			local hint = error_handler.get_hint("render")
+			assert.truthy(hint)
+			assert.are.same("string", type(hint))
+			assert.truthy(#hint > 0)
+		end)
+
+		it("returns hint for hook errors", function()
+			local hint = error_handler.get_hint("hook")
+			assert.truthy(hint)
+			assert.truthy(#hint > 0)
+		end)
+
+		it("returns hint for effect errors", function()
+			local hint = error_handler.get_hint("effect")
+			assert.truthy(hint)
+			assert.truthy(#hint > 0)
+		end)
+
+		it("returns hint for interaction errors", function()
+			local hint = error_handler.get_hint("interaction")
+			assert.truthy(hint)
+			assert.truthy(#hint > 0)
+		end)
+
+		it("returns hint for viewport errors", function()
+			local hint = error_handler.get_hint("viewport")
+			assert.truthy(hint)
+			assert.truthy(#hint > 0)
+		end)
+
+		it("returns generic hint for unknown error types", function()
+			local hint = error_handler.get_hint("unknown_type")
+			assert.truthy(hint)
+			assert.truthy(#hint > 0)
+		end)
+	end)
+end)

--- a/tests/unit/mount_error_spec.lua
+++ b/tests/unit/mount_error_spec.lua
@@ -1,0 +1,142 @@
+pcall(require, "luacov")
+---@module "luassert"
+
+local error_handler = require("ascii-ui.utils.error_handler")
+local fiber = require("ascii-ui.fiber")
+local ui = require("ascii-ui")
+
+describe("mount-level error handling", function()
+	describe("component returns wrong type", function()
+		it("produces informative error when component returns string instead of table", function()
+			local Broken = ui.createComponent("BrokenReturn", function()
+				return "not a table"
+			end, {})
+
+			local ok, err = pcall(fiber.render, Broken)
+
+			assert.is_false(ok)
+			assert.truthy(err:find("BrokenReturn"), "error should mention component name")
+			assert.truthy(err:find("expected.*list") or err:find("FiberNode"), "error should mention expected type")
+		end)
+
+		it("produces informative error when component returns nil", function()
+			local Broken = ui.createComponent("BrokenNil", function()
+				return nil
+			end, {})
+
+			local ok, err = pcall(fiber.render, Broken)
+
+			assert.is_false(ok)
+			assert.truthy(err:find("BrokenNil"), "error should mention component name")
+		end)
+
+		it("produces informative error when component returns non-FiberNode table", function()
+			local Broken = ui.createComponent("BrokenTable", function()
+				return { "not", "fibers" }
+			end, {})
+
+			local ok, err = pcall(fiber.render, Broken)
+
+			assert.is_false(ok)
+			assert.truthy(err:find("BrokenTable"), "error should mention component name")
+		end)
+	end)
+
+	describe("component function error", function()
+		it("includes component path when component throws during render", function()
+			local Inner = ui.createComponent("Inner", function()
+				error("inner error")
+			end, {})
+
+			local Outer = ui.createComponent("Outer", function()
+				return { Inner() }
+			end, {})
+
+			local ok, err = pcall(fiber.render, Outer)
+
+			assert.is_false(ok)
+			assert.truthy(err:find("Outer"), "error should mention Outer")
+			assert.truthy(err:find("Inner"), "error should mention Inner")
+			assert.truthy(err:find("inner error"), "error should contain original message")
+		end)
+
+		it("uses error_handler format for component errors", function()
+			local Broken = ui.createComponent("BrokenComp", function()
+				error("component failed")
+			end, {})
+
+			local ok, err = pcall(fiber.render, Broken)
+
+			assert.is_false(ok)
+			-- Should use the new error format
+			assert.truthy(err:find("%[render%]") or err:find("component error"), "error should use new format")
+			assert.truthy(err:find("BrokenComp"), "error should mention component name")
+		end)
+	end)
+
+	describe("hook errors", function()
+		it("includes component context when hook fails", function()
+			local Broken = ui.createComponent("BrokenHook", function()
+				-- Simulate a hook error by calling a hook-like function that errors
+				error("hook error in render")
+			end, {})
+
+			local ok, err = pcall(fiber.render, Broken)
+
+			assert.is_false(ok)
+			assert.truthy(err:find("BrokenHook"), "error should mention component name")
+			assert.truthy(err:find("hook error"), "error should contain hook error message")
+		end)
+	end)
+
+	describe("effect errors", function()
+		it("includes component context when effect fails", function()
+			local FiberNode = require("ascii-ui.fibernode")
+			local node = FiberNode.new({
+				type = "EffectComp",
+				pendingEffects = {
+					function()
+						error("effect failed")
+					end,
+				},
+			})
+
+			local ok, err = pcall(function()
+				node:run_pending()
+			end)
+
+			assert.is_false(ok)
+			assert.truthy(err:find("EffectComp"), "error should mention component name")
+			assert.truthy(err:find("effect failed"), "error should contain effect error message")
+			-- Should use new error format
+			assert.truthy(err:find("%[effect%]") or err:find("effect error"), "error should use new format")
+		end)
+	end)
+
+	describe("error display", function()
+		it("can convert error to displayable lines", function()
+			local err = error_handler.create_error("render", "Root > App", "test error")
+			local lines = error_handler.render_error_to_lines(err)
+
+			assert.are.same("table", type(lines))
+			assert.is_true(#lines > 0)
+
+			-- All lines should be strings
+			for _, line in ipairs(lines) do
+				assert.are.same("string", type(line))
+			end
+		end)
+
+		it("error display includes all necessary information", function()
+			local err = error_handler.create_error("render", "Root > App > MenuItem", "expected list, got string")
+			local lines = error_handler.render_error_to_lines(err)
+			local display = table.concat(lines, "\n")
+
+			assert.truthy(display:find("RENDER ERROR"))
+			assert.truthy(display:find("render"))
+			assert.truthy(display:find("Root > App > MenuItem"))
+			assert.truthy(display:find("expected list, got string"))
+			assert.truthy(display:find("Hint"))
+		end)
+	end)
+end)


### PR DESCRIPTION
# Informative Error Handling for Render Failures

This PR implements comprehensive error handling for render failures in ascii-ui.nvim, addressing issue #46.

## Summary

Previously, errors during component rendering would crash the plugin with unhelpful error messages. This PR introduces a dedicated error handling system that:

1. **Catches errors** at the mount level (both initial render and rerender)
2. **Formats errors consistently** with component path context
3. **Displays errors in the viewport** instead of crashing
4. **Provides helpful hints** based on error type

## Changes

### New Module: `error_handler.lua`

Created `lua/ascii-ui/utils/error_handler.lua` with:

- **Error types**: `render`, `hook`, `effect`, `interaction`, `viewport`
- **`format_error(err_type, component_path, message)`**: Formats errors consistently as `[type] in <ComponentPath>: message`
- **`create_error(err_type, component_path, message)`**: Creates structured error objects
- **`render_error_to_lines(err)`**: Converts errors to displayable buffer lines
- **`get_hint(err_type)`**: Returns helpful hints for each error type

### Updated Modules

**`fiber.lua`**:
- Moved `componentPath` function before `reconcileChildren` (fixes forward reference)
- Updated `reconcileChildren` to use error_handler for validation errors
- Updated `performUnitOfWork` to use error_handler for component errors

**`fibernode.lua`**:
- Updated `run_pending` to use error_handler for effect errors
- Added validation in `unwrap_closure` to check return type before flattening
- Provides clear error message when component returns non-table value

**`mount.lua`**:
- Wrapped initial `render()` call in xpcall
- Wrapped `rerender()` in state_change listener with xpcall
- Added `render_error_buffer()` helper to create error display buffer
- Errors are now rendered into the viewport with red text instead of crashing

## Example Error Output

When a component returns the wrong type:

```
═══ RENDER ERROR ═══

Type: render
Component: Root > App > MenuItem
Message: Component must return a list (table) of FiberNode or BufferLine objects, got string

Hint: Components must return a list (table) of FiberNode or BufferLine objects.
      Did you forget to wrap your return value?
      
      Example:
        return { Segment:new({ content = "hello" }):wrap() }

═══════════════════
```

## Testing

Added comprehensive test coverage:

- **`tests/unit/error_handler_spec.lua`**: 23 tests for error handler module
  - Error formatting for all error types
  - Error-to-lines conversion
  - Hint generation
  - Edge cases (nil/empty component paths)

- **`tests/unit/mount_error_spec.lua`**: 9 tests for mount-level error handling
  - Component returns wrong type (string, nil, non-FiberNode table)
  - Component throws during render
  - Hook errors with component context
  - Effect errors with component context
  - Error display conversion

All existing tests continue to pass:
- `tests/unit/component_error_spec.lua` ✓
- `tests/unit/fibernode_run_pending_spec.lua` ✓

## Verification

- ✅ All tests pass (`make test`)
- ✅ Linting passes (`lx lint` - 0 warnings, 0 errors)
- ✅ Formatting passes (`stylua --check .`)
- ✅ Backward compatible (existing error tests still pass)

## Future Work

This PR implements a lightweight error boundary at the mount level. Future enhancements could include:

- Per-component error boundaries (React-style)
- Error recovery mechanisms
- More detailed stack traces
- Configurable error display themes

Closes #46
