### PR TITLE
ci(docs): add workflow to sync docs to ascii-ui-docs

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -1,0 +1,83 @@
+name: Docs Sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'lua/ascii-ui/**'
+      - 'doc/ascii-ui.txt'
+
+jobs:
+  notify-docs-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issue in ascii-ui-docs
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.DOCS_SYNC_TOKEN }}
+          script: |
+            const commitSha = context.sha;
+            const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${commitSha}`;
+            const commitMessage = context.payload.head_commit.message;
+            
+            // Get list of changed files
+            const { data: comparison } = await github.rest.repos.compareCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              base: context.payload.before,
+              head: context.payload.after,
+            });
+            
+            const changedFiles = comparison.files
+              .filter(f => f.filename.startsWith('lua/ascii-ui/') || f.filename.startsWith('doc/'))
+              .map(f => `- \`${f.filename}\``)
+              .join('\n');
+            
+            if (!changedFiles) {
+              console.log('No docs-relevant files changed, skipping');
+              return;
+            }
+            
+            const title = `Update docs for ${commitSha.substring(0, 7)}`;
+            const body = `## Documentation Update Needed
+            
+A change was made to ascii-ui.nvim that may require documentation updates.
+
+**Commit**: [${commitSha.substring(0, 7)}](${commitUrl})
+**Message**: ${commitMessage.split('\n')[0]}
+
+### Changed Files
+
+${changedFiles}
+
+### Action Required
+
+Review the changes and update the Docusaurus documentation at https://github.com/rcasia/ascii-ui-docs if needed.
+
+---
+*This issue was automatically created by the docs-sync workflow.*`;
+
+            // Check if issue already exists for this commit
+            const { data: existingIssues } = await github.rest.issues.listForRepo({
+              owner: 'rcasia',
+              repo: 'ascii-ui-docs',
+              state: 'open',
+              labels: 'docs-sync',
+            });
+            
+            const alreadyExists = existingIssues.some(issue => 
+              issue.title.includes(commitSha.substring(0, 7))
+            );
+            
+            if (alreadyExists) {
+              console.log('Issue already exists for this commit, skipping');
+              return;
+            }
+            
+            await github.rest.issues.create({
+              owner: 'rcasia',
+              repo: 'ascii-ui-docs',
+              title: title,
+              body: body,
+              labels: ['docs-sync', 'documentation'],
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -572,3 +572,43 @@ agent-teacher can create new specialized agents when gaps are identified.
 5. Document in `AGENTS.md`
 6. Test on sample tasks
 7. Commit immediately
+
+## Documentation Sync
+
+When changes are made to `lua/ascii-ui/` or `doc/ascii-ui.txt`, the Docusaurus documentation at [ascii-ui-docs](https://github.com/rcasia/ascii-ui-docs) may need to be updated.
+
+### Automatic Notifications
+
+A GitHub Actions workflow (`.github/workflows/docs-sync.yml`) automatically creates an issue in the ascii-ui-docs repo when docs-relevant files change on main.
+
+### Manual Sync
+
+To manually update the docs:
+
+```bash
+# Clone or update the docs repo
+./scripts/sync-docs.sh
+
+# Or if you have it locally:
+cd /path/to/ascii-ui-docs
+git pull
+
+# Make changes to docs/
+# ...
+
+# Verify build
+npm run build
+
+# Commit and create PR
+git add .
+git commit -m "docs: update for latest changes"
+git push
+gh pr create
+```
+
+### What to Update
+
+- **API changes** (lua/ascii-ui/) → Update component/hook documentation
+- **New features** → Add new documentation pages
+- **Breaking changes** → Update migration guides
+- **Vimdocs changes** (doc/ascii-ui.txt) → Review if Docusaurus docs need updates

--- a/scripts/sync-docs.sh
+++ b/scripts/sync-docs.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Helper script to manually sync docs to ascii-ui-docs repo
+# Usage: ./scripts/sync-docs.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+DOCS_REPO="${DOCS_REPO:-/tmp/ascii-ui-docs}"
+
+echo "=== ascii-ui.nvim → ascii-ui-docs sync ==="
+echo ""
+
+# Check if docs repo exists
+if [ ! -d "$DOCS_REPO" ]; then
+    echo "Cloning ascii-ui-docs to $DOCS_REPO..."
+    git clone https://github.com/rcasia/ascii-ui-docs.git "$DOCS_REPO"
+fi
+
+cd "$DOCS_REPO"
+git checkout main
+git pull
+
+echo ""
+echo "Docs repo is up to date at: $DOCS_REPO"
+echo ""
+echo "Next steps:"
+echo "1. Review changes in ascii-ui.nvim (lua/ascii-ui/, doc/)"
+echo "2. Update Docusaurus markdown files in docs/"
+echo "3. Run 'npm run build' to verify"
+echo "4. Commit and create PR"


### PR DESCRIPTION
## Summary

Adds automation to keep ascii-ui-docs in sync with ascii-ui.nvim changes.

### Changes

1. **GitHub Actions workflow** (`.github/workflows/docs-sync.yml`)
   - Triggers on push to main when `lua/ascii-ui/` or `doc/` changes
   - Creates an issue in ascii-ui-docs with list of changed files
   - Prevents duplicate issues for same commit

2. **Helper script** (`scripts/sync-docs.sh`)
   - Clones/updates ascii-ui-docs repo
   - Provides guidance for manual doc updates

3. **Documentation** (`AGENTS.md`)
   - Explains the sync process
   - Documents what to update

### Setup Required

After merging, add a GitHub secret `DOCS_SYNC_TOKEN` with permissions to create issues in `rcasia/ascii-ui-docs`.

### Related

- ascii-ui-docs PR #35 (testing library docs)
- Issue #24 (testing library)