### PR TITLE
fix(ci): handle edge cases in docs-sync workflow

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   notify-docs-repo:
     runs-on: ubuntu-latest
+    if: ${{ secrets.DOCS_SYNC_TOKEN != '' }}
     steps:
       - name: Create issue in ascii-ui-docs
         uses: actions/github-script@v7
@@ -18,14 +19,23 @@ jobs:
           script: |
             const commitSha = context.sha;
             const commitUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${commitSha}`;
-            const commitMessage = context.payload.head_commit.message;
+            const commitMessage = context.payload.head_commit?.message || 'No message';
             
             // Get list of changed files
+            const before = context.payload.before;
+            const after = context.payload.after;
+            
+            // Skip if before is all zeros (new branch) or same as after
+            if (!before || before === '0000000000000000000000000000000000000000' || before === after) {
+              console.log('Skipping: no valid before commit');
+              return;
+            }
+            
             const { data: comparison } = await github.rest.repos.compareCommits({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              base: context.payload.before,
-              head: context.payload.after,
+              base: before,
+              head: after,
             });
             
             const changedFiles = comparison.files
@@ -39,23 +49,25 @@ jobs:
             }
             
             const title = `Update docs for ${commitSha.substring(0, 7)}`;
-            const body = `## Documentation Update Needed
-            
-A change was made to ascii-ui.nvim that may require documentation updates.
-
-**Commit**: [${commitSha.substring(0, 7)}](${commitUrl})
-**Message**: ${commitMessage.split('\n')[0]}
-
-### Changed Files
-
-${changedFiles}
-
-### Action Required
-
-Review the changes and update the Docusaurus documentation at https://github.com/rcasia/ascii-ui-docs if needed.
-
----
-*This issue was automatically created by the docs-sync workflow.*`;
+            const body = [
+              '## Documentation Update Needed',
+              '',
+              'A change was made to ascii-ui.nvim that may require documentation updates.',
+              '',
+              `**Commit**: [${commitSha.substring(0, 7)}](${commitUrl})`,
+              `**Message**: ${commitMessage.split('\n')[0]}`,
+              '',
+              '### Changed Files',
+              '',
+              changedFiles,
+              '',
+              '### Action Required',
+              '',
+              'Review the changes and update the Docusaurus documentation at https://github.com/rcasia/ascii-ui-docs if needed.',
+              '',
+              '---',
+              '*This issue was automatically created by the docs-sync workflow.*',
+            ].join('\n');
 
             // Check if issue already exists for this commit
             const { data: existingIssues } = await github.rest.issues.listForRepo({


### PR DESCRIPTION
## Summary

Fixes the docs-sync workflow that was failing with 'workflow file issue' error.

### Changes

1. Added conditional to skip job if `DOCS_SYNC_TOKEN` secret not set
2. Handle null/missing `head_commit` in payload
3. Handle edge case where `before` is null or all zeros (new branch)
4. Handle case where `before === after` (force push)
5. Fixed YAML parsing by using array join instead of multi-line template literal

### Testing

The workflow will now:
- Skip gracefully if secret not configured (no error)
- Handle all push event edge cases
- Only create issues when there are actual docs-relevant changes
- Parse correctly as valid YAML

Related to PR #71