### PR TITLE
fix(docs): use consistent output filename regardless of working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ test/xdg/local/state/nvim
 debug.lua
 debug/
 
+# Prevent wrong-named doc files (e.g. ascii-ui-dev.txt from /tmp/ascii-ui-dev/)
+doc/ascii-ui-*.txt
+!doc/ascii-ui.txt
+

--- a/scripts/gendocs.lua
+++ b/scripts/gendocs.lua
@@ -126,10 +126,10 @@ hooks.block_pre = function(b)
 	end
 end
 
--- Allow overriding output via environment variable
+-- Allow overriding output via environment variable; default to doc/ascii-ui.txt
+-- so the output filename is consistent regardless of working directory name.
 local output = os.getenv("DOC_OUTPUT_FILE")
 if output == nil or output == "" then
-	mini.generate(project_files, nil, { hooks = hooks })
-else
-	mini.generate(project_files, output, { hooks = hooks })
+	output = "doc/ascii-ui.txt"
 end
+mini.generate(project_files, output, { hooks = hooks })


### PR DESCRIPTION
## Summary

Fixes `make docs` generating wrong output filename when working directory name doesn't match `ascii-ui`.

### Problem

When agents work in directories like `/tmp/ascii-ui-dev/`, `make docs` generates `doc/ascii-ui-dev.txt` instead of `doc/ascii-ui.txt`. This causes:
- Wrong output filename
- Duplicate tag errors if leftover wrong-named files exist

### Root Cause

In `scripts/gendocs.lua`, when `DOC_OUTPUT_FILE` env var was not set, `mini.generate()` was called with `nil` as the output path. mini.doc then derives the output filename from the current working directory name.

### Fix

1. **`scripts/gendocs.lua`**: Always pass explicit output path to `mini.generate()`, defaulting to `doc/ascii-ui.txt`. `DOC_OUTPUT_FILE` env var still overrides when set.
2. **`.gitignore`**: Added rule for `doc/ascii-ui-*.txt` with negation `!doc/ascii-ui.txt` to prevent wrong-named files from being accidentally tracked.

### Verification

- [x] `make docs` generates `doc/ascii-ui.txt` from any directory
- [x] `make docs-check` passes
- [x] `make check` passes
- [x] `make test` passes (all unit + e2e + bench tests)

[agent: ascii-ui-dev]