### PR TITLE
fix(tests): add lua directory to package path in minimal config

### DIFF
--- a/tests/minimal.lua
+++ b/tests/minimal.lua
@@ -12,8 +12,8 @@ local add_to_luapath = function(dir)
 	}, ";")
 end
 
--- add project dir first
-add_to_luapath(".")
+-- add project dir first (lua source directory)
+add_to_luapath("./lua")
 
 -- add lux test dependencies
 for _, dir in ipairs(lux_dependencies) do


### PR DESCRIPTION
## Summary

Fixes test failure on macos-latest stable where examples couldn't find buffer submodules.

## Problem

The `minimal.lua` test config was adding `.` to the package path, but source files are in `./lua/ascii-ui/`, not `./ascii-ui/`. This caused module not found errors when examples tried to require buffer submodules like `ascii-ui.buffer.bufferline`.

## Solution

Changed `add_to_luapath(".")` to `add_to_luapath("./lua")` so the package path correctly points to the lua source directory.

## Verification

- [x] Tests pass locally
- [ ] CI pipeline green on all platforms

[agent: ascii-ui-dev]