### PR TITLE
fix(ci): remove expression wrapper from job-level if

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   notify-docs-repo:
     runs-on: ubuntu-latest
-    if: ${{ secrets.DOCS_SYNC_TOKEN != '' }}
+    if: secrets.DOCS_SYNC_TOKEN != ''
     steps:
       - name: Create issue in ascii-ui-docs
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

Fixes the docs-sync workflow YAML parsing error.

### The Issue

Job-level `if` conditions in GitHub Actions are already in an expression context and don't need the `${{ }}` wrapper. Using it causes a workflow file parsing error.

### The Fix

Changed:
```yaml
if: ${{ secrets.DOCS_SYNC_TOKEN != '' }}
```

To:
```yaml
if: secrets.DOCS_SYNC_TOKEN != ''
```

### Reference

From GitHub Actions docs: "When you use expressions in an `if` conditional, you may omit the expression syntax (`${{ }}`) because GitHub automatically evaluates the `if` conditional as an expression."

Related to PR #72