### PR TITLE
fix(tests): resolve flaky hasFocusable test

### DIFF
--- a/lua/ascii-ui/components/create-component.lua
+++ b/lua/ascii-ui/components/create-component.lua
@@ -5,6 +5,13 @@ local memoize = require("ascii-ui.utils.memoize")
 
 local component_tags = {}
 
+-- Counter for generating unique closure IDs
+local next_closure_id = 0
+local function generate_closure_id()
+	next_closure_id = next_closure_id + 1
+	return string.format("closure_%d", next_closure_id)
+end
+
 --- @alias ascii-ui.PropsType
 ---| "nil"
 ---| "number"
@@ -73,7 +80,7 @@ local function createComponent(name, functional_component, types)
 	local component_function = setmetatable({}, {
 		__is_a_component = true,
 		__call = function(_, ...)
-			local closure_id = tostring({})
+			local closure_id = generate_closure_id()
 			logger.debug("Creating closure for component '%s' with id %s", name, closure_id)
 			local _args = { ... }
 			local factory, props


### PR DESCRIPTION
## Summary

Fixes the flaky test `hasFocusable checks for focusable with text` in `tests/unit/testing_spec.lua`.

### Root Cause

The `closure_id` in `create-component.lua` was generated using `tostring({})`, which returns a string containing the memory address of a temporary table (e.g., `"table: 0x55a1b2c3d4e5"`). Lua's garbage collector can reuse memory addresses, causing the memoize cache key to collide across different component invocations. When this happened, the memoize function returned a stale closure from a previous test run, which had old hook state, causing the test to fail intermittently.

### Fix

Replaced `tostring({})` with a monotonically increasing counter (`generate_closure_id()`) that guarantees unique closure IDs regardless of GC behavior.

### Verification

- [x] Test passes consistently (ran 5+ times locally)
- [x] `make check` passes
- [x] `make test` passes

[agent: ascii-ui-dev]