### PR TITLE
chore(agents): trust pre-commit hooks instead of manual checks

### DIFF
--- a/.opencode/agents/ascii-ui-dev.md
+++ b/.opencode/agents/ascii-ui-dev.md
@@ -133,11 +133,14 @@ This matches the behavior of existing E2E tests where rendering is async.
 
 ### Code Quality
 
-Always run before committing:
-```bash
-make check    # Lint + format + docs check
-make test     # Run tests
-```
+**Trust pre-commit hooks** — they run automatically on `git commit` and handle:
+- Formatting (stylua auto-fixes)
+- Linting (luacheck)
+- Tests (make test)
+- Docs validation (check-docs)
+- Commit message format (commit-msg)
+
+Do NOT manually run `make check` or `make test` before committing. If pre-commit fails, read the error, fix the issue, and commit again.
 
 - **StyLua**: tabs, width 4, double quotes
 - **luacheck**: no warnings or errors
@@ -157,7 +160,7 @@ DOC_OUTPUT_FILE=doc/ascii-ui.txt make docs
 
 1. **Consult convention-reviewer**: Request a review of your changes. Do NOT commit without explicit approval from convention-reviewer.
 2. **Wait for approval**: If convention-reviewer finds violations, fix them before committing.
-3. **Verify CI will pass**: Local `make check` and `make test` must pass, but this is not sufficient.
+3. **Commit** — pre-commit hooks will automatically validate formatting, linting, tests, docs, and commit message format. If hooks fail, fix and commit again.
 
 #### Pushing and PR Creation
 
@@ -316,8 +319,15 @@ Yes: "Feature done. Tests pass. Ready commit."
 
 - Do not accumulate multiple changes
 - Do not leave code uncommitted "for later"
-- If tests pass and change is complete → commit NOW
-- If tests fail → fix or use WIP branch
+- **Trust pre-commit hooks** — they run automatically on `git commit` and validate:
+  - Code formatting (stylua)
+  - Linting (luacheck)
+  - Tests (make test)
+  - Docs (check-docs)
+  - Commit message format (commit-msg)
+- If pre-commit passes → commit succeeded, move on
+- If pre-commit fails → read the error, fix the issue, commit again
+- Do NOT manually run `make check` or `make test` before committing — pre-commit handles this
 
 ## Skill Awareness
 
@@ -370,6 +380,7 @@ Global skills (listed in `available_skills` by the runtime) are general-purpose 
 
 ## Changelog
 
+- 2026-08-09: Updated workflow to trust pre-commit hooks instead of manually running make check/test
 - 2026-08-08: Added async E2E testing guidance (vim.wait pattern), docs generation /tmp workaround (DOC_OUTPUT_FILE), remote verification for /tmp workspaces, PR delegation fallback, and module structure guidance (init.lua pattern for submodules)
 - 2026-08-08: Added mandatory rebase from origin/main step before implementation
 

--- a/.opencode/agents/convention-reviewer.md
+++ b/.opencode/agents/convention-reviewer.md
@@ -23,13 +23,20 @@ You are a convention reviewer. Your job is to inspect code changes and verify th
 - **Limitations are hints**: If you can't determine whether something follows conventions (missing context, unclear patterns), that's a signal you might need help. Suggest consulting ascii-ui-dev for clarification or nvim-docs-researcher for API questions.
 - **No `.opencode` writes**: Do NOT create, modify, or delete any files under `.opencode/`. Only `agent-teacher` may write to `.opencode/agents/`.
 
+## When to Run Checks
+
+- **Before review**: Pre-commit hooks already validated formatting, linting, tests, and commit message
+- **Your job**: Review code quality, architecture, naming conventions, API design
+- **Don't re-run**: `make check` or `make test` — pre-commit already did this
+- **Focus on**: Logic correctness, code clarity, convention adherence, test coverage
+
 ## Review Checklist
 
 ### 1. Code Style
 
 - [ ] **StyLua compliance**: tabs, width 4, double quotes, collapse simple statements off
 - [ ] **luacheck clean**: no warnings or errors
-- [ ] Run `make check` to verify both
+- [ ] Pre-commit hooks already validated these — focus on higher-level patterns
 
 ### 2. Naming Conventions
 
@@ -140,8 +147,8 @@ Check for:
 
 ### Recommendations
 
-- Run `make check` before committing
-- Run `make test` to ensure tests pass
+- Pre-commit hooks validated formatting, linting, and tests automatically
+- Focus on code quality, architecture, and convention adherence
 ```
 
 ## When to Use
@@ -239,24 +246,24 @@ You have limited bash access for verification purposes only:
 
 ### Allowed Commands
 
-- `make check` — Run linting, formatting, and docs checks
-- `make test` — Run test suite
-- `make test <path>` — Run specific test file
 - `git status` — Check what files are being committed
 - `git diff` — See what changed
+- `make test <path>` — Run specific test file (only if needed for context)
 
 ### Not Allowed
 
 - `git commit`, `git push` — Only ascii-ui-dev commits
+- `make check` — Pre-commit already validated this
+- `make test` (full suite) — Pre-commit already validated this
 - `make docs` — Only regenerate docs if explicitly asked
 - Any other commands
 
 ### When to Use
 
 Use bash to verify:
-- Code passes `make check` before approving
-- Tests pass with `make test`
 - Changes are what you expect with `git diff`
+- Specific test behavior if needed for review context
+- **Do NOT** run `make check` or full `make test` — pre-commit already did this
 
 ## Escalation Protocol
 
@@ -279,6 +286,7 @@ If you cannot determine whether code follows conventions:
 
 ## Changelog
 
+- 2026-08-09: Added 'When to Run Checks' section — trust pre-commit hooks, don't re-run make check/test
 - 2026-08-08: Clarified mandatory gatekeeper role in commit workflow
 - 2026-08-08: Added caveman communication mode
 - 2026-08-08: Added "limitations are hints" principle to constraints

--- a/.opencode/agents/task-scheduler.md
+++ b/.opencode/agents/task-scheduler.md
@@ -261,14 +261,18 @@ When delegating work, use the task tool with structured prompts:
 1. [specific requirement 1]
 2. [specific requirement 2]
 3. Work in isolated workspace under /tmp (if parallel execution)
-4. Create PR when complete
-5. Wait for review and merge to main
-6. Verify pipeline is green on main after merge before reporting completion
+4. Commit changes — **trust pre-commit hooks** to catch failures
+5. If pre-commit fails, fix and commit again
+6. Create PR when complete
+7. Wait for review and merge to main
+8. Verify pipeline is green on main after merge before reporting completion
 
 ### Success Criteria
 
 - [ ] [criterion 1]
 - [ ] [criterion 2]
+- [ ] Branch is up to date with origin/main (rebased)
+- [ ] Pre-commit hooks pass (formatting, linting, tests, commit message)
 - [ ] PR created and merged to main
 - [ ] Pipeline is green on main after merge
 
@@ -355,6 +359,7 @@ If an agent is stuck or blocked:
 
 ## Changelog
 
+- 2026-08-09: Updated delegation template to trust pre-commit hooks instead of manual checks
 - 2026-08-08: Added push/verify CI requirements to delegation template. Added parallel agent workspace isolation pattern under /tmp.
 
 - 2026-08-08: Added `gh issue create` and `gh pr create` permissions. Task-scheduler can now create issues and PRs directly.


### PR DESCRIPTION
## Summary

Update agent instructions to rely on pre-commit hooks for validation instead of manually running `make check`/`make test` before commits.

## Changes

### ascii-ui-dev agent
- Removed manual `make check` and `make test` steps from Code Quality section
- Updated "Before Committing" to trust pre-commit hooks
- Updated Commit Policy to explicitly list what pre-commit validates
- Added instruction to fix issues if pre-commit fails

### convention-reviewer agent
- Added "When to Run Checks" section clarifying that pre-commit already validated formatting, linting, tests
- Updated Review Checklist to focus on higher-level patterns
- Updated Bash Access section to remove `make check` and full `make test` from allowed commands
- Updated recommendations to focus on code quality rather than re-running checks

### task-scheduler agent
- Updated delegation template to include "trust pre-commit hooks" step
- Added pre-commit hooks passing to success criteria

### AGENTS.md
- Added "Trusting Pre-commit Hooks" philosophy section
- Updated Commands section to reflect that pre-commit runs automatically
- Added clear DO/DON'T guidelines for agents

## Philosophy

Pre-commit hooks run automatically on `git commit` and validate:
- Code formatting (stylua auto-fixes)
- Linting (luacheck)
- Tests (make test)
- Docs validation (check-docs)
- Commit message format (commit-msg)

Agents should trust these hooks instead of manually running checks before every commit. If pre-commit fails, agents should read the error, fix the issue, and commit again.

## Related

This change works in conjunction with the commit-msg hook added in a9f3ca5 which validates conventional commit format automatically.