### PR TITLE
refactor(examples): remove vim.defer_fn from simon-says useEffect

### DIFF
--- a/examples/simon-says.lua
+++ b/examples/simon-says.lua
@@ -9,6 +9,7 @@ local Button = ui.components.Button
 local Paragraph = ui.components.Paragraph
 local useState = ui.hooks.useState
 local useEffect = ui.hooks.useEffect
+local useTimeout = ui.hooks.useTimeout
 
 local COLORS = {
 	RED = "#FF6B6B",
@@ -33,6 +34,7 @@ local function App()
 	local gamePhase, setGamePhase = useState("idle")
 	local currentFlash, setCurrentFlash = useState(0)
 	local flashVisible, setFlashVisible = useState(false)
+	local pendingNextRound, setPendingNextRound = useState(false)
 
 	-- Start a new game
 	local function startGame()
@@ -42,6 +44,7 @@ local function App()
 		setGamePhase("showing")
 		setCurrentFlash(0)
 		setFlashVisible(false)
+		setPendingNextRound(false)
 	end
 
 	-- Add to sequence after successful round
@@ -69,10 +72,8 @@ local function App()
 				if score + 1 > highScore then
 					setHighScore(score + 1)
 				end
-				-- Wait a bit before showing next sequence
-				vim.defer_fn(function()
-					nextRound()
-				end, 1000)
+				-- Signal to start next round after delay
+				setPendingNextRound(true)
 			end
 		else
 			-- Wrong! Game over
@@ -80,30 +81,34 @@ local function App()
 		end
 	end
 
-	-- Sequence playback logic
+	-- Start showing first flash when entering "showing" phase
 	useEffect(function()
-		if gamePhase ~= "showing" then
-			return
+		if gamePhase == "showing" and currentFlash == 0 and not flashVisible then
+			setFlashVisible(true)
 		end
+	end, { gamePhase })
 
-		if currentFlash >= #sequence then
-			-- Done showing sequence, wait for input
-			vim.defer_fn(function()
-				setGamePhase("input")
-			end, 500)
-			return
-		end
+	-- Hide flash after 600ms when visible
+	useTimeout(function()
+		setFlashVisible(false)
+	end, flashVisible and gamePhase == "showing" and 600 or nil)
 
-		-- Show flash
+	-- Advance to next flash after 300ms when hidden
+	useTimeout(function()
+		setCurrentFlash(currentFlash + 1)
 		setFlashVisible(true)
-		vim.defer_fn(function()
-			setFlashVisible(false)
-			-- Move to next flash after a delay
-			vim.defer_fn(function()
-				setCurrentFlash(currentFlash + 1)
-			end, 300)
-		end, 600)
-	end, { gamePhase, currentFlash })
+	end, not flashVisible and gamePhase == "showing" and currentFlash < #sequence and 300 or nil)
+
+	-- Transition to input phase after 500ms when sequence complete
+	useTimeout(function()
+		setGamePhase("input")
+	end, not flashVisible and gamePhase == "showing" and currentFlash >= #sequence and 500 or nil)
+
+	-- Start next round after 1000ms when pending
+	useTimeout(function()
+		setPendingNextRound(false)
+		nextRound()
+	end, pendingNextRound and 1000 or nil)
 
 	-- Flash indicator
 	local showingFlash = gamePhase == "showing" and currentFlash < #sequence


### PR DESCRIPTION
## Summary

Refactors `examples/simon-says.lua` to remove `vim.defer_fn` calls from inside `useEffect`, replacing them with proper `useTimeout` hooks.

## Problem

The previous implementation used `vim.defer_fn` inside `useEffect` for sequence playback timing, which is an antipattern. Effects should manage timing through their dependency mechanism and timing hooks, not manual timer calls.

## Solution

Replaced nested `vim.defer_fn` calls with separate `useTimeout` hooks that react to state changes:

- **Hide flash after 600ms** when visible
- **Advance to next flash after 300ms** when hidden  
- **Transition to input after 500ms** when sequence complete
- **Start next round after 1000ms** when pending

Added `pendingNextRound` state to handle the delay between round completion and starting the next round.

## Changes

- Import `useTimeout` hook
- Add `pendingNextRound` state for round transition timing
- Split sequence playback into separate `useTimeout` calls with conditional delays
- Remove all `vim.defer_fn` from `useEffect`
- Keep all game logic intact

## Verification

- ✅ No `vim.defer_fn` inside `useEffect`
- ✅ Sequence playback timing works correctly
- ✅ Uses ascii-ui timing hooks properly
- ✅ Game still playable
- ✅ Passes luacheck and stylua
- ✅ All tests pass
- ✅ Pre-commit hooks pass

[agent: ascii-ui-dev]